### PR TITLE
Multi Plans

### DIFF
--- a/prisma/schema/migrations/20251108050007_plan_is_disabled/migration.sql
+++ b/prisma/schema/migrations/20251108050007_plan_is_disabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Plan" ADD COLUMN     "is_disabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema/plan.prisma
+++ b/prisma/schema/plan.prisma
@@ -4,6 +4,7 @@ model Plan {
   description       String?
   price             Float
   annualDiscount    Float              @default(0) @map("annual_discount")
+  isDisabled        Boolean            @default(false) @map("is_disabled")
   createdAt         DateTime           @default(now()) @map("created_at")
   updatedAt         DateTime           @updatedAt @map("updated_at")
   Categories        Category[]

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -133,6 +133,7 @@ export class ArticlesController {
 		const article = await this.articlesService.findOne(
 			id,
 			user ? user.role : Role.USER,
+			user.id,
 		);
 
 		return article;

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -30,7 +30,7 @@ export class ArticlesService {
 		return article;
 	}
 
-	async findOne(id: number, userRole: Role) {
+	async findOne(id: number, userRole: Role, userId?: string) {
 		const article = await prisma.article.findUnique({
 			where: { id },
 			select: {
@@ -64,11 +64,15 @@ export class ArticlesService {
 			},
 		});
 
+		let userSub = await prisma.userSubscription.findFirst({
+			where: { userId, isActive: true },
+		});
+
 		if (!article) {
 			throw new NotFoundException(`Article with ID ${id} not found`);
 		}
 
-		if (userRole === Role.USER && article.Category.planId) {
+		if (userRole === Role.USER && article.Category.planId != userSub?.planId) {
 			throw new ForbiddenException(
 				`Article with ID ${id} is locked for users without a subscription`,
 			);

--- a/src/plans/plans.controller.ts
+++ b/src/plans/plans.controller.ts
@@ -1,6 +1,7 @@
 import {
 	Body,
 	Controller,
+	Delete,
 	Get,
 	HttpCode,
 	HttpStatus,
@@ -73,12 +74,24 @@ export class PlansController {
 	@UseGuards(JwtAuthGuard, RolesGuard)
 	@Roles(Role.ADMIN)
 	@HttpCode(HttpStatus.OK)
-	@ResponseMessage('Plan retrieved successfully!')
+	@ResponseMessage('Plan updated successfully!')
 	@Put(':planId')
 	async update(
 		@Param('planId') planId: number,
 		@Body() body: CreatePlanRequestDto,
 	) {
 		return await this.plansService.update(planId, body);
+	}
+
+	@ApiResponse({
+		status: HttpStatus.NO_CONTENT,
+	})
+	@UseGuards(JwtAuthGuard, RolesGuard)
+	@Roles(Role.ADMIN)
+	@HttpCode(HttpStatus.NO_CONTENT)
+	@ResponseMessage('Plan delete successfully!')
+	@Delete(':planId')
+	async delete(@Param('planId') planId: number) {
+		return await this.plansService.delete(planId);
 	}
 }

--- a/src/plans/plans.service.ts
+++ b/src/plans/plans.service.ts
@@ -1,8 +1,4 @@
-import {
-	ConflictException,
-	Injectable,
-	NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import prisma from '../shared/utils/prisma/client';
 import { CreatePlanRequestDto } from './dtos/create-plan.dto';
 
@@ -13,14 +9,6 @@ export class PlansService {
 	}
 
 	async create(data: CreatePlanRequestDto) {
-		const existingPlan = await prisma.plan.findFirst();
-
-		if (existingPlan) {
-			throw new ConflictException(
-				`A plan already exists. Only one plan is allowed.`,
-			);
-		}
-
 		return prisma.plan.create({
 			data: {
 				name: data.name,
@@ -54,6 +42,19 @@ export class PlansService {
 				price: data.price,
 				annualDiscount: data.annualDiscount ?? undefined,
 			},
+		});
+	}
+
+	async delete(planId: number) {
+		const plan = await this.findOne(planId);
+
+		if (!plan || plan.isDisabled) {
+			throw new NotFoundException(`Plan not found`);
+		}
+
+		return prisma.plan.update({
+			where: { id: planId },
+			data: { isDisabled: true },
 		});
 	}
 }


### PR DESCRIPTION
This pull request introduces several improvements to the plans and articles modules, primarily adding soft-deletion for plans, updating the schema to support this, and refining article access logic based on user subscriptions. The most significant changes are grouped below:

**Plans Module Enhancements:**

* Added a new `is_disabled` boolean column to the `Plan` model and database schema to support soft-deletion of plans. (`prisma/schema/migrations/20251108050007_plan_is_disabled/migration.sql`, `prisma/schema/plan.prisma`) [[1]](diffhunk://#diff-56c940ef71994e06aa9b2f7f8f125839a4453ab4f55e673491674180cb80bb00R1-R2) [[2]](diffhunk://#diff-a2453d546bcbbdb03ecc271935f10bf663e332a74dd575da06a4867e05d7abaaR7)
* Implemented a `DELETE /plans/:planId` endpoint that marks a plan as disabled instead of deleting it from the database. The service method checks if the plan exists and is not already disabled before updating. (`src/plans/plans.controller.ts`, `src/plans/plans.service.ts`) [[1]](diffhunk://#diff-9065beffacf7abb0ecb04eabd34a5cec42c4a523146c04e865e916be83c32062L76-R96) [[2]](diffhunk://#diff-c3b665e03b7c19fbc4df5c7de1e00fbdd40cd8c0677b9a42ca022409f4bce549R47-R59)
* Removed the restriction that only one plan can exist, allowing for multiple plans to be created. (`src/plans/plans.service.ts`)

**Articles Access Control:**

* Updated the `ArticlesService.findOne` method to also accept a `userId` and check the user's active subscription. Now, users can only access articles if their subscription matches the article's plan. (`src/articles/articles.controller.ts`, `src/articles/articles.service.ts`) [[1]](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R136) [[2]](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbL33-R33) [[3]](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbR67-R75)

**Minor Improvements:**

* Fixed response messages and improved HTTP status codes for plan update and delete endpoints. (`src/plans/plans.controller.ts`)
* Cleaned up unused imports in `PlansService`. (`src/plans/plans.service.ts`)